### PR TITLE
10.13 - Added Cut/Copy/Paste/Select All to prompt context menu (#34)

### DIFF
--- a/ClaudeCodeControl.xaml
+++ b/ClaudeCodeControl.xaml
@@ -166,6 +166,16 @@
                          PreviewMouseWheel="PromptTextBox_PreviewMouseWheel">
 					<TextBox.ContextMenu>
 						<ContextMenu>
+							<MenuItem Header="Cut" Command="ApplicationCommands.Cut" InputGestureText="Ctrl+X"
+							          CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+							<MenuItem Header="Copy" Command="ApplicationCommands.Copy" InputGestureText="Ctrl+C"
+							          CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+							<MenuItem Header="Paste" Command="ApplicationCommands.Paste" InputGestureText="Ctrl+V"
+							          CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+							<Separator/>
+							<MenuItem Header="Select All" Command="ApplicationCommands.SelectAll" InputGestureText="Ctrl+A"
+							          CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+							<Separator/>
 							<MenuItem Header="Clear Prompt History" Click="ClearPromptHistoryMenuItem_Click"/>
 						</ContextMenu>
 					</TextBox.ContextMenu>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("10.12.0.0")]
-[assembly: AssemblyFileVersion("10.12.0.0")]
+[assembly: AssemblyVersion("10.13.0.0")]
+[assembly: AssemblyFileVersion("10.13.0.0")]

--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ Click the update button and the extension will handle the update process. Agents
 
 ## Version History
 
+### Version 10.13
+- **Cut/Copy/Select All added to prompt context menu** (#34): The prompt textbox's context menu previously only exposed "Clear Prompt History", which replaced WPF's default Cut/Copy/Paste entries. Standard Cut, Copy, Paste, and Select All items (bound to `ApplicationCommands`) now appear above the history action, so right-clicking the prompt works like any normal text box.
+
 ### Version 10.12
 - **Qwen Code provider removed**: Qwen Code is no longer bundled as a provider option. The `AiProvider` enum now uses explicit ordinals and skips `6` (the retired `QwenCode` value) so existing user settings that still reference it fall back to `ClaudeCode` cleanly via a defensive `Enum.IsDefined` guard in `LoadSettings`. Menu entry, availability detection, install instructions, Enter-key branch, workspace-change handler, detach label, and update flow for Qwen Code have all been removed.
 - **Terminal row minimum reduced to 20px**: The MainGrid terminal row `MinHeight` dropped from 60px to 20px (both normal and inverted layouts), allowing the splitter to travel further down so the prompt area can grow larger.

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="10.12" Language="en-US" Publisher="Daniel Carvalho Liedke" />
+        <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="10.13" Language="en-US" Publisher="Daniel Carvalho Liedke" />
         <DisplayName>Claude Code Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">A Visual Studio .NET extension that provides a better interface for Claude Code CLI with support for multi-line prompts, image and file attachments. Codex, Cursor, Opencode and Windsurf also supported. Also integrated diff tool to review code change made by AI Agents.</Description>
         <MoreInfo>https://github.com/dliedke/ClaudeCodeExtension</MoreInfo>


### PR DESCRIPTION
The prompt textbox's custom ContextMenu previously only contained "Clear
Prompt History", which replaced WPF's default Cut/Copy/Paste entries.
Added standard Cut, Copy, Paste, and Select All items bound to
ApplicationCommands with explicit CommandTarget routing to the
PlacementTarget so right-clicking the prompt now works like any normal
text box.