### PR TITLE
Add Switch Account button to Claude Usage tool window

### DIFF
--- a/ClaudeUsageControl.xaml
+++ b/ClaudeUsageControl.xaml
@@ -71,6 +71,12 @@
                     <ComboBoxItem Content="2m"  Tag="120"/>
                 </ComboBox>
 
+                <Button x:Name="SwitchAccountButton" Style="{StaticResource UsageButtonStyle}"
+                        ToolTip="Show the claude.ai account switcher (e.g. swap between Team and Personal accounts)"
+                        Click="SwitchAccountButton_Click">
+                    <TextBlock Text="👤 Switch Account" FontSize="12"/>
+                </Button>
+
                 <Button x:Name="OpenInBrowserButton" Style="{StaticResource UsageButtonStyle}"
                         ToolTip="Open claude.ai/settings/usage in your default browser"
                         Click="OpenInBrowserButton_Click">

--- a/ClaudeUsageControl.xaml.cs
+++ b/ClaudeUsageControl.xaml.cs
@@ -448,7 +448,7 @@ namespace ClaudeCodeVS
   }
   function tick(){
     const section = findSection();
-    if (TRIM && section) trimPage(section);
+    if (TRIM && !window.__claudeSuppressTrim && section) trimPage(section);
     postSnapshot();
   }
   tick();
@@ -692,6 +692,59 @@ namespace ClaudeCodeVS
         private void OpenInBrowserButton_Click(object sender, RoutedEventArgs e)
         {
             try { Process.Start(new ProcessStartInfo(UsageUrl) { UseShellExecute = true }); } catch { }
+        }
+
+        /// <summary>
+        /// Reveals the claude.ai native account switcher menu inside the embedded
+        /// WebView. The trim CSS hides the avatar button by default (it lives in
+        /// nav/header/sidebar), so this:
+        ///   1. Removes the trim style and clears trim-related data attributes
+        ///   2. Stops the tick() from re-applying the trim by setting a flag
+        ///   3. Clicks the user avatar to open the org/account picker
+        /// After the user picks an account, the page navigates to the new
+        /// org context. When the user wants the focused usage view back,
+        /// they can press Refresh — the next NavigationCompleted re-runs the
+        /// injected script which re-trims if TRIM=true.
+        /// </summary>
+        private void SwitchAccountButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var core = WebView?.CoreWebView2;
+                if (core == null) return;
+                string js = @"
+(function(){
+  window.__claudeSuppressTrim = true;
+  var s = document.getElementById('__claude_usage_trim_css__');
+  if (s) s.remove();
+  document.querySelectorAll('[data-claude-usage-hide]').forEach(function(el){ el.removeAttribute('data-claude-usage-hide'); });
+  document.querySelectorAll('[data-claude-usage-path]').forEach(function(el){ el.removeAttribute('data-claude-usage-path'); });
+  document.querySelectorAll('[data-claude-usage-keep]').forEach(function(el){ el.removeAttribute('data-claude-usage-keep'); });
+  // Try several selectors for the avatar / user menu trigger.
+  var selectors = [
+    'button[aria-label*=""profile menu"" i]',
+    'button[aria-label*=""user menu"" i]',
+    'button[aria-label*=""account menu"" i]',
+    'button[aria-label*=""account"" i]',
+    'button[data-testid*=""user-menu"" i]',
+    'button[data-testid*=""account-menu"" i]',
+    'button[data-testid*=""profile"" i]',
+    '[data-testid=""user-menu-button""]'
+  ];
+  for (var i = 0; i < selectors.length; i++) {
+    var el = document.querySelector(selectors[i]);
+    if (el) { el.click(); return true; }
+  }
+  return false;
+})();";
+#pragma warning disable VSTHRD110 // ExecuteScriptAsync fire-and-forget is intentional
+                _ = core.ExecuteScriptAsync(js);
+#pragma warning restore VSTHRD110
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("ClaudeUsageControl: SwitchAccountButton_Click failed: " + ex);
+            }
         }
 
 #pragma warning disable VSTHRD100 // async void Click handler is required by WPF

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("10.36.0.0")]
-[assembly: AssemblyFileVersion("10.36.0.0")]
+[assembly: AssemblyVersion("10.37.0.0")]
+[assembly: AssemblyFileVersion("10.37.0.0")]

--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ Claude will write the `SKILL.md` file with the proper frontmatter and instructio
 
 ## Version History
 
+### Version 10.37
+- **Switch Account button for Claude Usage**: New **👤 Switch Account** button in the Claude Usage tool window toolbar. Clicking it temporarily disables the page-trim CSS and clicks the claude.ai user avatar to surface the native account/organization switcher (e.g. swap between a Team account and a Personal Max account in the embedded view). Click **↻ Refresh** to return to the focused usage view.
+
 ### Version 10.36
 - **Claude Code session history**: New 📜 toolbar button (visible only for Claude Code / Claude Code WSL) opens a dialog listing past sessions for the current workspace, parsed from `~/.claude/projects/<encoded-cwd>/*.jsonl`. Each entry shows timestamp, message count, token usage, and the first user prompt. Resume relaunches Claude with `--resume <id>`; **Resume Last Session** maps to `claude --continue`. Delete removes the transcript on disk. Works for both native Windows and WSL Claude Code (WSL paths resolved via `wslpath -w`).
 - **Drag & drop file attachments**: Files dragged onto the **Prompt / Paste Image** area are now attached as if added via the 📎 button. Folders are skipped, duplicates are filtered out.

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="10.36" Language="en-US" Publisher="Daniel Carvalho Liedke" />
+        <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="10.37" Language="en-US" Publisher="Daniel Carvalho Liedke" />
         <DisplayName>Claude Code Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">A Visual Studio .NET extension that provides a better interface for Claude Code CLI with support for multi-line prompts, image and file attachments. Codex, Cursor, Opencode and Windsurf also supported. Also integrated diff tool to review code change made by AI Agents.</Description>
         <MoreInfo>https://github.com/dliedke/ClaudeCodeExtension</MoreInfo>


### PR DESCRIPTION
## Summary
- Adds a **👤 Switch Account** button to the Claude Usage tool window toolbar
- Clicking it removes the trim CSS, suppresses re-trimming via a `__claudeSuppressTrim` flag, and clicks the claude.ai user avatar (multiple selector fallbacks) to surface the native account/organization switcher
- Lets users swap between multiple Claude accounts (e.g. a Team account and a Personal Max account) inside the embedded view; **↻ Refresh** returns to the focused usage view
- Bumps to **10.37** (`AssemblyInfo.cs`, `source.extension.vsixmanifest`, `README.md` history entry)

## Motivation
The trim CSS in the embedded usage view hides `nav`/`header`/`aside`/`footer`, which means the user avatar — the only entry point to claude.ai's account switcher — is unreachable. Users with multiple Anthropic accounts (e.g. a work Team org and a personal Max plan) had no way to switch between them without leaving Visual Studio.

## Test plan
- [ ] F5 → experimental VS instance with the VSIX loaded
- [ ] Open Claude Usage tool window (📊 toolbar button or inline usage panel click)
- [ ] Verify the new **👤 Switch Account** button is visible between **Auto-refresh** and **🌐 Open in Browser**
- [ ] Click it: page un-trims and the claude.ai account switcher popover opens
- [ ] Pick a different account/org and confirm the page navigates into that org's context
- [ ] Click **↻ Refresh**: the usage view re-trims to the focused bars layout