### PR TITLE
Activate VS and terminal tool window when embedded terminal is clicked

### DIFF
--- a/Controls/ClaudeCodeControl.Interop.cs
+++ b/Controls/ClaudeCodeControl.Interop.cs
@@ -55,6 +55,9 @@ namespace ClaudeCodeVS
         private const uint WM_LBUTTONUP = 0x0202;
         private const uint WM_MOUSEWHEEL = 0x020A;
 
+        // GetAncestor flags
+        private const uint GA_ROOT = 2;
+
         // RedrawWindow flags
         private const uint RDW_INVALIDATE = 0x0001;
         private const uint RDW_ERASE = 0x0004;
@@ -252,6 +255,24 @@ namespace ClaudeCodeVS
         /// </summary>
         [DllImport("user32.dll")]
         private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        /// <summary>
+        /// Retrieves a handle to the foreground window (the window with which the user is currently working)
+        /// </summary>
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        /// <summary>
+        /// Retrieves the handle to the ancestor of the specified window
+        /// </summary>
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetAncestor(IntPtr hWnd, uint gaFlags);
+
+        /// <summary>
+        /// Brings the specified window to the top of the Z order without activating it
+        /// </summary>
+        [DllImport("user32.dll")]
+        private static extern bool BringWindowToTop(IntPtr hWnd);
 
         /// <summary>
         /// Synthesizes keystrokes, mouse motions, and button clicks
@@ -513,6 +534,12 @@ namespace ClaudeCodeVS
         /// </summary>
         [DllImport("user32.dll")]
         private static extern bool IsChild(IntPtr hWndParent, IntPtr hWnd);
+
+        /// <summary>
+        /// Retrieves a handle to the window at the specified screen point (topmost, hit-tested)
+        /// </summary>
+        [DllImport("user32.dll")]
+        private static extern IntPtr WindowFromPoint(POINT Point);
 
         #endregion
 

--- a/Controls/ClaudeCodeControl.Terminal.cs
+++ b/Controls/ClaudeCodeControl.Terminal.cs
@@ -1925,6 +1925,101 @@ namespace ClaudeCodeVS
         }
 
         /// <summary>
+        /// Reacts to a click on the embedded terminal panel: makes sure VS is on top of the
+        /// Win32 Z-order and that our tool window is the active pane inside VS.
+        /// </summary>
+        private void ActivateEmbeddedTerminalOnClick(POINT screenPoint)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (!IsScreenPointInsideActiveTerminalPanel(screenPoint))
+            {
+                return;
+            }
+
+            // Verify the click really hit the terminal (not another app fully covering VS at the
+            // same screen coordinates). Done once here so both activation steps below can trust it.
+            if (WindowFromPoint(screenPoint) != terminalHandle)
+            {
+                return;
+            }
+
+            BringVisualStudioToForegroundIfNeeded();
+            ActivateTerminalToolWindowIfNeeded();
+        }
+
+        /// <summary>
+        /// Brings the VS top-level window to the front of the Win32 Z-order if it isn't already.
+        /// </summary>
+        private void BringVisualStudioToForegroundIfNeeded()
+        {
+            IntPtr foreground = GetForegroundWindow();
+            if (foreground == terminalHandle)
+            {
+                return;
+            }
+
+            IntPtr root = GetAncestor(terminalHandle, GA_ROOT);
+            if (root == IntPtr.Zero || !IsWindow(root) || foreground == root)
+            {
+                return;
+            }
+
+            BringWindowToTop(root);
+            SetForegroundWindow(root);
+        }
+
+        /// <summary>
+        /// Marks the embedded terminal's tool window as the active pane inside VS, if it isn't already.
+        /// </summary>
+        private void ActivateTerminalToolWindowIfNeeded()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (IsTerminalToolWindowActive())
+            {
+                return;
+            }
+
+#pragma warning disable VSSDK007 // Fire-and-forget is intentional here
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ActivateTerminalToolWindowAsync();
+            });
+#pragma warning restore VSSDK007
+        }
+
+        /// <summary>
+        /// Returns true when the embedded terminal's tool window is the currently active pane inside VS.
+        /// </summary>
+        private bool IsTerminalToolWindowActive()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var myFrame = ((_isTerminalDetached && _detachedTerminalWindow != null)
+                ? _detachedTerminalWindow.Frame
+                : _toolWindow?.Frame) as IVsWindowFrame;
+            if (myFrame == null)
+            {
+                return false;
+            }
+
+            var monitor = Package.GetGlobalService(typeof(SVsShellMonitorSelection)) as IVsMonitorSelection;
+            if (monitor == null)
+            {
+                return false;
+            }
+
+            if (Microsoft.VisualStudio.ErrorHandler.Failed(monitor.GetCurrentElementValue(
+                (uint)Microsoft.VisualStudio.VSConstants.VSSELELEMID.SEID_WindowFrame, out object active)))
+            {
+                return false;
+            }
+
+            return ReferenceEquals(active, myFrame);
+        }
+
+        /// <summary>
         /// Returns true when the supplied screen point is inside the active terminal panel.
         /// </summary>
         private bool IsScreenPointInsideActiveTerminalPanel(POINT screenPoint)
@@ -2024,6 +2119,11 @@ namespace ClaudeCodeVS
                 }
                 else if (message == WM_LBUTTONDOWN)
                 {
+                    // Low-level mouse hooks are invoked on the thread that installed them
+                    // (the UI thread, see InstallMouseHook), so the UI-thread requirement is met.
+#pragma warning disable VSTHRD010
+                    ActivateEmbeddedTerminalOnClick(info.pt);
+#pragma warning restore VSTHRD010
                     BeginWindowsTerminalSelectionTracking(info.pt);
                 }
                 else if (message == WM_MOUSEMOVE)


### PR DESCRIPTION
A simple fix for issue https://github.com/dliedke/ClaudeCodeExtension/issues/54.

-----
When VS is occluded by another app, clicking the embedded terminal would not bring VS to the foreground because the terminal window lives in conhost.exe / wt.exe and is attached via SetParent, breaking the Win32 activation chain. Inside VS, the terminal tool window also did not become the active pane after such a click since the docking system tracks active panes separately from Win32 foreground.

The low-level mouse hook now intercepts WM_LBUTTONDOWN on the terminal panel and runs two independent activation steps:

BringVisualStudioToForegroundIfNeeded: walks GA_ROOT up the real parent chain (works for conhost which keeps WS_POPUP after SetParent) and calls BringWindowToTop / SetForegroundWindow on the VS top-level when it isn't already foreground.
ActivateTerminalToolWindowIfNeeded: queries IVsMonitorSelection for the current active frame and, if it isn't ours, fires IVsWindowFrame.Show() through JoinableTaskFactory.RunAsync so the docking-system active highlight is updated.
A WindowFromPoint hit-test gates both steps so a click that lands on another app fully covering VS at the same screen coordinates does not falsely activate VS.

-----
Windows Terminal does not have this issue, but I think it no need to do any special handling.