### PR TITLE
Fix "Send Selection to Claude Code" missing in HTML editor (issue #57)

### DIFF
--- a/ClaudeCodeExtensionPackage.vsct
+++ b/ClaudeCodeExtensionPackage.vsct
@@ -9,6 +9,9 @@
       <Group guid="guidClaudeCodeExtensionPackageCmdSet" id="EditorContextMenuGroup" priority="0x0600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
       </Group>
+      <Group guid="guidClaudeCodeExtensionPackageCmdSet" id="HtmlCodeContextMenuGroup" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_HTMLCODE"/>
+      </Group>
     </Groups>
 
     <Buttons>
@@ -29,6 +32,12 @@
       </Button>
     </Buttons>
 
+    <CommandPlacements>
+      <CommandPlacement guid="guidClaudeCodeExtensionPackageCmdSet" id="EditorSendSelectionCommandId" priority="0x0100">
+        <Parent guid="guidClaudeCodeExtensionPackageCmdSet" id="HtmlCodeContextMenuGroup"/>
+      </CommandPlacement>
+    </CommandPlacements>
+
     <Bitmaps>
       <Bitmap guid="guidImages" href="app.ico" usedList="bmpIcon"/>
     </Bitmaps>
@@ -40,6 +49,7 @@
     <GuidSymbol name="guidClaudeCodeExtensionPackageCmdSet" value="{11111111-2222-3333-4444-555555555555}">
       <IDSymbol name="ClaudeCodeToolWindowCommandId" value="0x0100" />
       <IDSymbol name="EditorContextMenuGroup" value="0x1020" />
+      <IDSymbol name="HtmlCodeContextMenuGroup" value="0x1021" />
       <IDSymbol name="EditorSendSelectionCommandId" value="0x0201" />
     </GuidSymbol>
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("10.64.0.0")]
-[assembly: AssemblyFileVersion("10.64.0.0")]
+[assembly: AssemblyVersion("10.65.0.0")]
+[assembly: AssemblyFileVersion("10.65.0.0")]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ This binds a Claude Code skill that shells out to OpenAI Codex to audit pending 
 
 ## Version History
 
+### Version 10.65
+- "Send Selection to Claude Code" context menu option now appears in HTML file editors, in addition to standard code editors.
+
 ### Version 10.64
 - XAML controls and their code-behind moved into a dedicated UI/ folder. No user-facing changes.
 

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="10.64" Language="en-US" Publisher="Daniel Carvalho Liedke" />
+        <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="10.65" Language="en-US" Publisher="Daniel Carvalho Liedke" />
         <DisplayName>Claude Code Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">Embedded terminal for Claude Code, Codex, Cursor Agent, Open Code, Windsurf, PI, and Antigravity inside Visual Studio. Multi-line prompts, image/file attachments, integrated diff viewer.</Description>
         <MoreInfo>https://github.com/dliedke/ClaudeCodeExtension</MoreInfo>


### PR DESCRIPTION
## Summary

- Adds `HtmlCodeContextMenuGroup` parented to `IDM_VS_CTXT_HTMLCODE` in the VSCT command table
- Uses `CommandPlacements` to surface the existing "Send Selection to Claude Code" button in the HTML source editor context menu, alongside the standard code window it already covered
- Bumps version to 10.65

## Test plan

- [ ] Open a `.html` file in VS 2022, select some text, right-click → "Send Selection to Claude Code" should appear
- [ ] Open a `.vue` file (or any standard code file like `.cs`, `.ts`), verify the option still appears as before
- [ ] Verify the button is disabled (but visible) when no text is selected in the HTML editor

Fixes #57

https://claude.ai/code/session_01QRbSFx4eCUEdLBhFfVntbU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRbSFx4eCUEdLBhFfVntbU)_