### PR TITLE
Recover trapped WPF keyboard focus from embedded terminal (issue #65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ ClaudeCodeExtension/
 - **Mouse hook** (`WH_MOUSE_LL`): Tracks Ctrl+Scroll zoom delta (persisted); converts plain left-drag to SHIFT+drag for WT text selection
 - **Post-startup**: `SchedulePostStartupTerminalAdjustments()` runs deferred resize + zoom replay; `SchedulePostSolutionLoadTerminalRefresh()` does 200/500/1000ms repaint passes after solution load
 - **Fresh PATH from registry**: `GetFreshPathFromRegistry()` reads PATH from `HKLM` and `HKCU` registry keys to detect newly installed tools (e.g. Windows Terminal) without requiring VS restart
+- **WPF keyboard-focus reclaim** (issue #65): `SetParent`ing the terminal (a separate-process window) into VS permanently joins that process's input queue with the VS UI thread, so keyboard focus is a single shared state. If it gets stuck on the terminal window, WPF's own `Focus()` won't always move native focus back — the prompt won't accept typing (caret stops blinking) and the provider menu can't be arrow-key navigated until VS restarts. `ClaudeCodeControl_PreviewMouseLeftButtonDown` (wired on the UserControl; a tunneling event, so it fires before any child handles the click) calls `ReclaimWpfKeyboardFocusIfStuck()`: when `GetFocus() != HwndSource.Handle` it `SetFocus`es the WPF host window, so a single click anywhere on the WPF surface restores typing. No-op when WPF already owns focus, so ordinary clicks pay nothing
 
 **Command patterns**:
 ```

--- a/Controls/ClaudeCodeControl.Interop.cs
+++ b/Controls/ClaudeCodeControl.Interop.cs
@@ -254,6 +254,13 @@ namespace ClaudeCodeVS
         private static extern bool SetFocus(IntPtr hWnd);
 
         /// <summary>
+        /// Retrieves the handle to the window that has the keyboard focus within the calling thread's
+        /// input queue (which includes the embedded terminal, whose input queue is joined to ours via SetParent).
+        /// </summary>
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetFocus();
+
+        /// <summary>
         /// Brings the window to the foreground and activates it
         /// </summary>
         [DllImport("user32.dll")]

--- a/Controls/ClaudeCodeControl.Terminal.cs
+++ b/Controls/ClaudeCodeControl.Terminal.cs
@@ -1658,6 +1658,51 @@ namespace ClaudeCodeVS
         }
 
         /// <summary>
+        /// A left-click anywhere on the WPF surface re-asserts native keyboard focus on the WPF
+        /// host window when the embedded terminal currently holds it.
+        ///
+        /// The terminal is a child window from a separate process re-parented into Visual Studio
+        /// via SetParent, which permanently joins that process's input queue with the VS UI thread.
+        /// Keyboard focus is therefore a single shared state: once it lands on the terminal window,
+        /// WPF's own Focus() does not always move native focus back, so the prompt can't be typed
+        /// into (the caret stops blinking) and the provider menu can't be navigated with the arrow
+        /// keys until Visual Studio is restarted. Re-asserting native focus on the WPF host here
+        /// restores typing with a single click instead of a restart. See issue #65.
+        /// </summary>
+        private void ClaudeCodeControl_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            ReclaimWpfKeyboardFocusIfStuck();
+        }
+
+        /// <summary>
+        /// Moves native keyboard focus to the WPF host window when it is currently held elsewhere
+        /// in the shared input queue (the embedded terminal). No-op when WPF already owns it, so
+        /// it adds no overhead to ordinary clicks.
+        /// </summary>
+        private void ReclaimWpfKeyboardFocusIfStuck()
+        {
+            try
+            {
+                var source = System.Windows.PresentationSource.FromVisual(this) as System.Windows.Interop.HwndSource;
+                if (source == null || source.Handle == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                // Any WPF element with keyboard focus reports the HwndSource window as the native
+                // focus, so a mismatch means the terminal (or another joined window) holds it.
+                if (GetFocus() != source.Handle)
+                {
+                    SetFocus(source.Handle);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"ReclaimWpfKeyboardFocusIfStuck error: {ex.Message}");
+            }
+        }
+
+        /// <summary>
         /// Replays the saved terminal zoom delta.
         /// Windows Terminal: batches Ctrl+= / Ctrl+- keystrokes through a single SendInput
         /// syscall. This is dramatically faster than the previous keybd_event loop (which

--- a/Controls/ClaudeCodeControl.cs
+++ b/Controls/ClaudeCodeControl.cs
@@ -91,6 +91,11 @@ namespace ClaudeCodeVS
             Loaded += ClaudeCodeControl_Loaded;
             Unloaded += ClaudeCodeControl_Unloaded;
             SizeChanged += ClaudeCodeControl_SizeChanged;
+
+            // Recover keyboard focus for the WPF UI (prompt box, provider menu navigation) when the
+            // embedded terminal has trapped it. PreviewMouseLeftButtonDown is a tunneling event, so
+            // this fires before any child marks the click handled. See ReclaimWpfKeyboardFocusIfStuck.
+            PreviewMouseLeftButtonDown += ClaudeCodeControl_PreviewMouseLeftButtonDown;
         }
 
         #endregion

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("10.79.0.0")]
-[assembly: AssemblyFileVersion("10.79.0.0")]
+[assembly: AssemblyVersion("10.80.0.0")]
+[assembly: AssemblyFileVersion("10.80.0.0")]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ This binds a Claude Code skill that shells out to OpenAI Codex to audit pending 
 
 ## Version History
 
+### Version 10.80
+- Fixed the prompt becoming unresponsive to the keyboard (cursor not blinking, arrow keys not switching agents) while the embedded terminal still accepted typing — clicking in the extension now restores keyboard input without restarting Visual Studio.
+
 ### Version 10.79
 - Fixed the prompt and its attached files being sent two or three times when the Send button (or Enter) was pressed again before a send finished.
 

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="10.79" Language="en-US" Publisher="Daniel Carvalho Liedke" />
+        <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="10.80" Language="en-US" Publisher="Daniel Carvalho Liedke" />
         <DisplayName>Claude Code Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">Embedded terminal for Claude Code, Codex, Cursor Agent, Open Code, Windsurf, PI, and Antigravity inside Visual Studio. Multi-line prompts, image/file attachments, integrated diff viewer.</Description>
         <MoreInfo>https://github.com/dliedke/ClaudeCodeExtension</MoreInfo>


### PR DESCRIPTION
## Problem (issue #65)

The extension intermittently becomes unresponsive to the keyboard: the prompt stops accepting keystrokes and its caret stops blinking, and the arrow keys no longer switch agents — yet the **mouse still works** and the embedded **terminal still accepts typing**. The only recovery was restarting Visual Studio.

## Root cause

The embedded terminal is a window owned by a **separate process** (conhost / wt.exe), re-parented into the VS tool window via `SetParent`. Re-parenting across process/thread boundaries **permanently joins the terminal process's input queue with the VS UI thread**, so keyboard focus becomes a single shared state across both.

When that shared focus lands on the terminal window and gets stuck there, WPF's own `Focus()` does not reliably move *native* keyboard focus back to the WPF host. The result is exactly the reported symptom: WPF UI (prompt box, provider-menu arrow navigation) gets no keystrokes and shows no caret, while the terminal — which holds the native focus — keeps working. Mouse input is unaffected because it is routed by cursor position, not focus.

## Fix

A left-click anywhere on the WPF surface now re-asserts native keyboard focus on the WPF host window when it is currently held elsewhere in the shared input queue:

- `ClaudeCodeControl_PreviewMouseLeftButtonDown` is wired on the `UserControl`. `PreviewMouseLeftButtonDown` is a **tunneling** event, so it fires before any child element handles the click.
- `ReclaimWpfKeyboardFocusIfStuck()` compares `GetFocus()` (native focus within the joined input queue) against the WPF `HwndSource.Handle`. On a mismatch it `SetFocus`es the WPF host window; otherwise it does nothing.

So a single click in the extension restores typing without a VS restart, and ordinary clicks (when WPF already owns focus) pay no cost.

## Changes
- `Controls/ClaudeCodeControl.Interop.cs` — add `GetFocus` P/Invoke.
- `Controls/ClaudeCodeControl.cs` — wire `PreviewMouseLeftButtonDown` on the control.
- `Controls/ClaudeCodeControl.Terminal.cs` — `ClaudeCodeControl_PreviewMouseLeftButtonDown` + `ReclaimWpfKeyboardFocusIfStuck()`.
- Version bump to **10.80** (`AssemblyInfo.cs`, `source.extension.vsixmanifest`), `README.md` + `CLAUDE.md` notes.

## Verification note
This is a Windows-only VSIX and was developed on a Linux session runner, so it has **not been compiled or run here**. Please verify in Visual Studio: reproduce the stuck state, then confirm a single click in the prompt area restores typing (caret blinks, agent arrow-key switching works) without restarting VS.

The change is deliberately a low-risk *recovery* path. If after testing you find a specific action that consistently traps focus (e.g. a background refresh re-asserting terminal focus), I can also target the root steal to prevent it happening in the first place.

https://claude.ai/code/session_011YZPctaVVCzegyDazsgbc2

---
_Generated by [Claude Code](https://claude.ai/code/session_011YZPctaVVCzegyDazsgbc2)_