### PR TITLE
Add reference-only Send Selection option

### DIFF
--- a/Controls/ClaudeCodeControl.SettingsDialog.cs
+++ b/Controls/ClaudeCodeControl.SettingsDialog.cs
@@ -72,6 +72,7 @@ namespace ClaudeCodeVS
             bool origSendWithCtrlEnter        = _settings.SendWithCtrlEnter;
             bool origSendLargeAsFile          = _settings.SendLargePromptsAsFile;
             bool origDisableClipboardSend     = _settings.DisableClipboardSend;
+            bool origSendSelectionRefOnly     = _settings.SendSelectionReferenceOnly;
             bool origAutoOpenChanges          = _settings.AutoOpenChangesOnPrompt;
             bool origInvertLayout             = _settings.InvertLayout;
             LayoutOrientation origOrientation = _settings.SelectedLayoutOrientation;
@@ -167,6 +168,12 @@ namespace ClaudeCodeVS
                 Margin = new Thickness(20, 0, 0, 0)
             };
             behaviorStack.Children.Add(disableClipboardWtHint);
+
+            var sendSelectionRefOnlyCheck = MakeCheckBox(
+                "Send selection as reference only (no code)",
+                "When enabled, \"Send Selection\" only inserts the file path and line numbers (e.g. \"File: foo.cs (lines 10-15)\"), without the selected code. The AI agent reads the file directly.",
+                origSendSelectionRefOnly, themeFg);
+            behaviorStack.Children.Add(sendSelectionRefOnlyCheck);
 
             // Auto-open Changes only applies inside git repos, but we keep the
             // checkbox visible so users can pre-toggle the setting before
@@ -568,6 +575,7 @@ namespace ClaudeCodeVS
                 sendEnterRadio.IsChecked = true;          // Send with Enter
                 largeAsFileCheck.IsChecked = false;
                 disableClipboardCheck.IsChecked = false;
+                sendSelectionRefOnlyCheck.IsChecked = false;
                 autoOpenCheck.IsChecked = false;
                 SelectComboByTag(fontSizeCombo, 12);
                 topRadio.IsChecked = true;                // Top layout
@@ -603,6 +611,7 @@ namespace ClaudeCodeVS
             bool newSendWithCtrlEnter = sendCtrlEnterRadio.IsChecked == true;
             bool newSendLargeAsFile = largeAsFileCheck.IsChecked == true;
             bool newDisableClipboardSend = disableClipboardCheck.IsChecked == true;
+            bool newSendSelectionRefOnly = sendSelectionRefOnlyCheck.IsChecked == true;
             bool newAutoOpenChanges = autoOpenCheck.IsChecked == true;
             int newFontSize = (fontSizeCombo.SelectedItem as ComboBoxItem)?.Tag is int fs ? fs : origFontSize;
             // Map the selected position back to orientation + invert.
@@ -668,6 +677,7 @@ namespace ClaudeCodeVS
             _settings.SendWithCtrlEnter       = newSendWithCtrlEnter;
             _settings.SendLargePromptsAsFile  = newSendLargeAsFile;
             _settings.DisableClipboardSend    = newDisableClipboardSend;
+            _settings.SendSelectionReferenceOnly = newSendSelectionRefOnly;
             _settings.AutoOpenChangesOnPrompt = newAutoOpenChanges;
             _settings.InvertLayout            = newInvertLayout;
             _settings.SelectedLayoutOrientation = newOrientation;

--- a/Controls/ClaudeCodeControl.UserInput.cs
+++ b/Controls/ClaudeCodeControl.UserInput.cs
@@ -636,11 +636,14 @@ namespace ClaudeCodeVS
                     snippet.AppendLine($"File: {displayPath} (lines {startLine}-{endLine})");
                 }
 
-                // Code fence with language
-                snippet.AppendLine($"```{langId}");
-                snippet.AppendLine(code.TrimEnd('\r', '\n'));
-                snippet.AppendLine("```");
-                snippet.AppendLine();
+                // Code fence with language (skipped when reference-only mode is on)
+                if (_settings?.SendSelectionReferenceOnly != true)
+                {
+                    snippet.AppendLine($"```{langId}");
+                    snippet.AppendLine(code.TrimEnd('\r', '\n'));
+                    snippet.AppendLine("```");
+                    snippet.AppendLine();
+                }
 
                 // Insert at current cursor position or append
                 int caretIndex = PromptTextBox.CaretIndex;

--- a/Models/ClaudeCodeModels.cs
+++ b/Models/ClaudeCodeModels.cs
@@ -319,6 +319,12 @@ namespace ClaudeCodeVS
         public bool DisableClipboardSend { get; set; } = false;
 
         /// <summary>
+        /// When true, "Send Selection" only inserts the file reference (path + line numbers)
+        /// without the code block. Default false.
+        /// </summary>
+        public bool SendSelectionReferenceOnly { get; set; } = false;
+
+        /// <summary>
         /// Saved position of the grid splitter (in pixels)
         /// </summary>
         public double SplitterPosition { get; set; } = 236.0; // Default pixel height for first row


### PR DESCRIPTION
## Summary
- Add a Behavior setting to send editor selections as file/line references only.
- Preserve the existing full code-block behavior by default.
- Reset the new setting to false with the Settings dialog defaults.

## Test Plan
- Built Release locally with MSBuild: 0 warnings, 0 errors.
- Manually verified in Visual Studio Experimental Instance that the setting appears and Send Selection omits code when enabled.
- Manually verified reference-only insertion does not add extra blank lines.
