### PR TITLE
v145.0: Keep the selected effort level after a code agent restart

### DIFF
--- a/Controls/ClaudeCodeControl.Terminal.cs
+++ b/Controls/ClaudeCodeControl.Terminal.cs
@@ -4793,6 +4793,16 @@ namespace ClaudeCodeVS
                 baseCommand = $"{baseCommand} --dangerously-skip-permissions";
             }
 
+            // The effort slider sends "/effort <level>", which the CLI applies to the running session
+            // only. A restart therefore started over at whatever level the CLI reads from its own
+            // settings, while the slider kept showing the last selection — "Max" on the slider next to
+            // a session that had silently fallen back. Passing the level as a launch flag closes that
+            // gap, exactly as native mode already does (see GetNativeEffortArgument). "Auto" is the
+            // extension's own "say nothing" and the one value the flag rejects, so it appends nothing
+            // and leaves the CLI's configured level untouched.
+            baseCommand = AppendClaudeEffortArgument(
+                baseCommand, _settings?.SelectedEffortLevel ?? EffortLevel.Auto);
+
             // Consume one-shot resume request if present — the session-history
             // dialog sets this just before triggering a terminal restart.
             string resumeArg = System.Threading.Interlocked.Exchange(ref _pendingResumeSessionId, null);
@@ -4828,6 +4838,22 @@ namespace ClaudeCodeVS
                 : $"set CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 && set CLAUDE_CODE_DISABLE_MOUSE=1 && {baseCommand}";
 
             return baseCommand;
+        }
+
+        /// <summary>
+        /// Appends the CLI's <c>--effort</c> launch flag for every level the slider offers, including
+        /// the undocumented "ultracode". <see cref="EffortLevel.Auto"/> is the extension's "leave it to
+        /// the CLI" choice and appends nothing. An unknown value only earns a warning on stderr, so a
+        /// future CLI dropping a level degrades to its default instead of failing the launch.
+        /// </summary>
+        internal static string AppendClaudeEffortArgument(string baseCommand, EffortLevel level)
+        {
+            if (level == EffortLevel.Auto)
+            {
+                return baseCommand;
+            }
+
+            return $"{baseCommand} --effort {level.ToString().ToLowerInvariant()}";
         }
 
         private static string QuoteProviderArgument(string value, bool isWsl)

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -41,8 +41,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("144.0.0.0")]
-[assembly: AssemblyFileVersion("144.0.0.0")]
+[assembly: AssemblyVersion("145.0.0.0")]
+[assembly: AssemblyFileVersion("145.0.0.0")]
 
 // Exposes internal helpers to the test project so the pure logic (path encoding, git status
 // parsing, WSL command building, prompt formatting) can be tested without a running Visual Studio.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Use native mode to avoid this issue.
 
 ## Version History
 
+### Version 145.0
+The effort level you select now survives a restart of the code agent — previously the new session quietly started at the CLI's own level while the slider still showed the previous selection.
+
 ### Version 144.0
 Native mode tables now render full grid lines around every cell (header and data rows), instead of just an underline below the header.
 

--- a/Tests/ClaudeLaunchArgumentTests.cs
+++ b/Tests/ClaudeLaunchArgumentTests.cs
@@ -1,0 +1,102 @@
+/* *******************************************************************************************************************
+ * Application: ClaudeCodeExtension
+ *
+ * Autor:  Daniel Carvalho Liedke / Claude Code
+ *
+ * Copyright © Daniel Carvalho Liedke 2026
+ * Usage and reproduction in any manner whatsoever without the written permission of Daniel Carvalho Liedke is strictly forbidden.
+ *
+ * Purpose: Covers the effort level the embedded terminal launches Claude Code with — the "/effort"
+ *          slash command only applies to the running session, so the level has to ride along as a
+ *          launch flag or every restart silently drops back while the slider still shows it.
+ *
+ * *******************************************************************************************************************/
+
+using System;
+using ClaudeCodeVS;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ClaudeCodeExtension.Tests
+{
+    [TestClass]
+    public class ClaudeLaunchArgumentTests
+    {
+        /// <summary>
+        /// "Auto" is the extension's own "leave it to the CLI" choice and the one value --effort
+        /// rejects, so a user who never touched the slider must see an unchanged command line.
+        /// </summary>
+        [TestMethod]
+        public void AppendClaudeEffortArgument_AddsNothingForAuto()
+        {
+            Assert.AreEqual(
+                "claude",
+                ClaudeCodeControl.AppendClaudeEffortArgument("claude", EffortLevel.Auto));
+        }
+
+        [TestMethod]
+        public void AppendClaudeEffortArgument_AppendsTheSelectedLevel()
+        {
+            Assert.AreEqual(
+                "claude --effort low",
+                ClaudeCodeControl.AppendClaudeEffortArgument("claude", EffortLevel.Low));
+
+            Assert.AreEqual(
+                "claude --effort medium",
+                ClaudeCodeControl.AppendClaudeEffortArgument("claude", EffortLevel.Medium));
+
+            Assert.AreEqual(
+                "claude --effort high",
+                ClaudeCodeControl.AppendClaudeEffortArgument("claude", EffortLevel.High));
+        }
+
+        /// <summary>
+        /// The enum spells these "XHigh" and "Ultracode"; the CLI only accepts them lowercased.
+        /// </summary>
+        [TestMethod]
+        public void AppendClaudeEffortArgument_LowercasesCompoundLevelNames()
+        {
+            Assert.AreEqual(
+                "claude --effort xhigh",
+                ClaudeCodeControl.AppendClaudeEffortArgument("claude", EffortLevel.XHigh));
+
+            Assert.AreEqual(
+                "claude --effort ultracode",
+                ClaudeCodeControl.AppendClaudeEffortArgument("claude", EffortLevel.Ultracode));
+
+            Assert.AreEqual(
+                "claude --effort max",
+                ClaudeCodeControl.AppendClaudeEffortArgument("claude", EffortLevel.Max));
+        }
+
+        /// <summary>
+        /// Every level the slider offers has to produce a flag — a level added to the enum without a
+        /// mapping would otherwise launch at the CLI default while the slider claims otherwise.
+        /// </summary>
+        [TestMethod]
+        public void AppendClaudeEffortArgument_CoversEveryLevelButAuto()
+        {
+            foreach (EffortLevel level in Enum.GetValues(typeof(EffortLevel)))
+            {
+                if (level == EffortLevel.Auto) continue;
+
+                string command = ClaudeCodeControl.AppendClaudeEffortArgument("claude", level);
+
+                StringAssert.StartsWith(command, "claude --effort ");
+                Assert.AreEqual(command, command.ToLowerInvariant(), $"{level} was not lowercased");
+            }
+        }
+
+        /// <summary>
+        /// The flag is appended to whatever the caller built so far, so it must not disturb the
+        /// arguments already on the command line.
+        /// </summary>
+        [TestMethod]
+        public void AppendClaudeEffortArgument_PreservesEarlierArguments()
+        {
+            Assert.AreEqual(
+                "claude --dangerously-skip-permissions --effort xhigh",
+                ClaudeCodeControl.AppendClaudeEffortArgument(
+                    "claude --dangerously-skip-permissions", EffortLevel.XHigh));
+        }
+    }
+}

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -6,7 +6,7 @@ Visual Studio Extension (VSIX) for VS 2022/2026 — integrates AI code assistant
 
 - Author: Daniel Carvalho Liedke (dliedke@gmail.com) | License: MIT
 - Repository: https://github.com/dliedke/ClaudeCodeExtension
-- Current Version: 144.0 | Target Framework: .NET Framework 4.7.2
+- Current Version: 145.0 | Target Framework: .NET Framework 4.7.2
 
 ---
 

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="144.0" Language="en-US" Publisher="Daniel Carvalho Liedke" />
+    <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="145.0" Language="en-US" Publisher="Daniel Carvalho Liedke" />
     <DisplayName>Claude Code Extension for Visual Studio</DisplayName>
     <Description xml:space="preserve">Claude Code, Codex, Cursor Agent, Open Code, Devin, PI, Antigravity, Reasonix inside Visual Studio. Image/file paste, diff viewer, actions when AI ends work, usage tracking, session history and more</Description>
     <MoreInfo>https://github.com/dliedke/ClaudeCodeExtension</MoreInfo>


### PR DESCRIPTION
## Problem

The effort slider sends `/effort <level>`, which Claude Code applies to the **running session only**. After "Restart code agent" — or a Visual Studio restart — the next session starts over at whatever level the CLI reads from its own settings, while the slider keeps showing the previous selection. The result is a slider reading "Max" next to a session that silently fell back.

Reproduced with Claude Code CLI 2.1.233. Session transcripts record the effort each assistant message ran at, which makes the fallback visible:

| session | `/effort` sent | effort in transcript |
|---|---|---|
| before restart | yes | `max` |
| before restart | yes | `max` |
| **after restart** | no | `xhigh` (the CLI's configured level) |

Native mode is not affected — it already passes the level at launch (`ClaudeCommandBuilder.Effort` / `GetNativeEffortArgument`), and the comment there describes exactly this failure: *"it was silently lost on every relaunch … while the composer still showed the old level."* The terminal path never got the same treatment.

## Fix

`GetClaudeCommand` appends `--effort <level>` to the launch command, so what the slider shows is what the session runs — restart or not.

## Notes

- `EffortLevel.Auto` appends nothing, so anyone who never touched the slider gets an unchanged command line and keeps whatever the CLI is configured with.
- `ultracode` is not listed in `claude --help` (which shows `low, medium, high, xhigh, max`) but is accepted, same as native mode already assumes. Verified: `--effort bogus` prints *"Warning: Unknown --effort value 'bogus' — ignoring it"*, `--effort ultracode` prints nothing, and a session launched with it reports the ultracode mode active while `--effort xhigh` does not.
- The slider keeps sending `/effort` for the session already running, so mid-session switching is unchanged.

## Version

Bumped to 145.0 across all four sources per `docs/CLAUDE.md` — `Properties/AssemblyInfo.cs`, `source.extension.vsixmanifest`, the README release notes and the `Current Version` line in `docs/CLAUDE.md`.

## Tests

- New `Tests/ClaudeLaunchArgumentTests.cs` — covers Auto (appends nothing), the plain levels, lowercasing of `XHigh`/`Ultracode`, every enum member but Auto producing a flag, and earlier arguments surviving.
- Full suite: 200/200 passing.
- Manually verified in the experimental hive: slider to Max → "Restart code agent" → the new session runs at `max` instead of falling back.
