### PR TITLE
v146.0: Fix Windows Terminal launch failing with apostrophe in user path (issue #138)

### DIFF
--- a/Controls/ClaudeCodeControl.Terminal.cs
+++ b/Controls/ClaudeCodeControl.Terminal.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -1193,6 +1194,33 @@ namespace ClaudeCodeVS
                             cmdProcess = new Process { StartInfo = wtStartInfo };
                             cmdProcess.Start();
                             LogTerminalLaunch($"wt.exe spawned: pid={cmdProcess.Id}");
+                        }
+                        catch (Win32Exception win32Ex) when (win32Ex.NativeErrorCode == 2 /* ERROR_FILE_NOT_FOUND */)
+                        {
+                            // wt.exe is normally an App Execution Alias — a reparse-point stub
+                            // under %LOCALAPPDATA%\Microsoft\WindowsApps that the OS resolves to
+                            // the packaged Windows Terminal app. Launching it via a raw
+                            // CreateProcess call (UseShellExecute = false) can fail with "the
+                            // system cannot find the file specified" even though the alias is
+                            // right there — reported with a workspace/user path containing an
+                            // apostrophe (issue #138), which raw CreateProcess appears not to
+                            // resolve reliably against the alias. ShellExecute goes through the
+                            // OS's own package activation instead, which resolves the alias
+                            // correctly regardless of what characters are in the working directory.
+                            LogTerminalLaunch($"wt.exe spawn via CreateProcess failed (file not found); retrying via ShellExecute");
+
+                            var shellStartInfo = new ProcessStartInfo
+                            {
+                                FileName = "wt.exe",
+                                Arguments = wtStartInfo.Arguments,
+                                UseShellExecute = true,
+                                WorkingDirectory = wtStartInfo.WorkingDirectory,
+                                WindowStyle = ProcessWindowStyle.Hidden
+                            };
+
+                            cmdProcess = new Process { StartInfo = shellStartInfo };
+                            cmdProcess.Start();
+                            LogTerminalLaunch($"wt.exe spawned via ShellExecute fallback: pid={cmdProcess.Id}");
                         }
                         catch (Exception ex)
                         {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -41,8 +41,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("145.0.0.0")]
-[assembly: AssemblyFileVersion("145.0.0.0")]
+[assembly: AssemblyVersion("146.0.0.0")]
+[assembly: AssemblyFileVersion("146.0.0.0")]
 
 // Exposes internal helpers to the test project so the pure logic (path encoding, git status
 // parsing, WSL command building, prompt formatting) can be tested without a running Visual Studio.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Use native mode to avoid this issue.
 
 ## Version History
 
+### Version 146.0
+Fixed Windows Terminal failing to launch with "The system cannot find the file specified" when the workspace or user profile path contains an apostrophe (issue #138). wt.exe is normally an App Execution Alias, and launching it via a raw CreateProcess call could fail to resolve the alias in that case; the launch now retries through ShellExecute, which resolves it reliably.
+
 ### Version 145.0
 The effort level you select now survives a restart of the code agent — previously the new session quietly started at the CLI's own level while the slider still showed the previous selection.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -6,7 +6,7 @@ Visual Studio Extension (VSIX) for VS 2022/2026 — integrates AI code assistant
 
 - Author: Daniel Carvalho Liedke (dliedke@gmail.com) | License: MIT
 - Repository: https://github.com/dliedke/ClaudeCodeExtension
-- Current Version: 145.0 | Target Framework: .NET Framework 4.7.2
+- Current Version: 146.0 | Target Framework: .NET Framework 4.7.2
 
 ---
 

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="145.0" Language="en-US" Publisher="Daniel Carvalho Liedke" />
+    <Identity Id="ClaudeCodeExtension.87de5d13-743e-46b3-b05e-24e1cbeca0c3" Version="146.0" Language="en-US" Publisher="Daniel Carvalho Liedke" />
     <DisplayName>Claude Code Extension for Visual Studio</DisplayName>
     <Description xml:space="preserve">Claude Code, Codex, Cursor Agent, Open Code, Devin, PI, Antigravity, Reasonix inside Visual Studio. Image/file paste, diff viewer, actions when AI ends work, usage tracking, session history and more</Description>
     <MoreInfo>https://github.com/dliedke/ClaudeCodeExtension</MoreInfo>


### PR DESCRIPTION
## Summary

Fixes #138 — switching the terminal type to "Windows Terminal" failed with:

> Failed to start embedded terminal: The system cannot find the file specified

when the user's profile/workspace path contains an apostrophe (e.g. `C:\Users\O'Brien\...`).

## Root cause

`wt.exe` is normally an **App Execution Alias** — a reparse-point stub under
`%LOCALAPPDATA%\Microsoft\WindowsApps` that the OS resolves to the packaged
Windows Terminal app. Launching it via a raw `CreateProcess` call
(`UseShellExecute = false`, which is what `Process.Start` does by default)
can fail to resolve that alias with "the system cannot find the file
specified" even though the file is right there — this surfaced for the
reporter with an apostrophe in their user/workspace path.

## Fix

The Windows Terminal launch now catches that specific failure
(`Win32Exception` with native error code 2 — `ERROR_FILE_NOT_FOUND`) and
retries through `ShellExecute`, which goes through the OS's own package
activation manager and resolves the App Execution Alias reliably,
regardless of the characters in the working directory. The existing
fallback path (bare `"wt.exe"` command prompt mode) and error reporting are
unaffected — this only adds a second attempt before the launch is reported
as failed.

## Testing

No Windows/Visual Studio environment is available in this session to build
or run the extension, so this was verified by careful code review only. The
change is narrowly scoped (a single additional `catch` clause around the
existing `wt.exe` spawn) and preserves all prior behavior when the primary
launch succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ABQceNyWtLbHec6xJ3tfAA)_