### PR TITLE
Re-assert the console code page while attached to the terminal

### DIFF
--- a/Controls/ClaudeCodeControl.AgentCompletion.cs
+++ b/Controls/ClaudeCodeControl.AgentCompletion.cs
@@ -922,6 +922,42 @@ namespace ClaudeCodeVS
         }
 
         /// <summary>
+        /// Code page the terminal is launched with - the launch script starts with "chcp 65001".
+        /// </summary>
+        private const uint TerminalLaunchCodePage = 65001;
+
+        /// <summary>
+        /// Puts the console back to the code page the terminal was launched with.
+        ///
+        /// The code page belongs to the console, not to the process that changes it, and that
+        /// console is shared with everything the agent spawns. A child that calls
+        /// SetConsoleOutputCP - PowerShell's [Console]::OutputEncoding, a chcp inside a shell
+        /// command, some .NET CLI tools - leaves it changed after it exits, and from then on
+        /// every byte the agent writes is decoded with the wrong code page. The panel stays
+        /// unreadable until the terminal is restarted, which costs the session's scrollback.
+        ///
+        /// We are attached to that console about once a second anyway, so putting it back here
+        /// is close to free and repairs the drift before the user has to act on it. Only output
+        /// written after the correction benefits; text already in the scroll buffer was damaged
+        /// when it was written and cannot be recovered.
+        /// </summary>
+        private void ReassertConsoleCodePage()
+        {
+            try
+            {
+                uint current = GetConsoleOutputCP();
+                if (current == 0 || current == TerminalLaunchCodePage) return;
+
+                LogTerminalLaunch($"console output CP drifted to {current}, restoring {TerminalLaunchCodePage}");
+                SetConsoleOutputCP(TerminalLaunchCodePage);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"ReassertConsoleCodePage: {ex.Message}");
+            }
+        }
+
+        /// <summary>
         /// Convenience wrapper: captures the console text and returns its stable hash
         /// (or null on any failure). Used by the arm path which only needs a baseline hash.
         /// </summary>
@@ -978,6 +1014,10 @@ namespace ClaudeCodeVS
                         return null;
                     }
                     attached = true;
+
+                    // A child of the agent may have left the console on a different code
+                    // page; while we are attached, put it back. See ReassertConsoleCodePage.
+                    ReassertConsoleCodePage();
 
                     handle = CreateFile("CONOUT$",
                         GENERIC_READ_CONSOLE | GENERIC_WRITE_CONSOLE,
@@ -1083,6 +1123,10 @@ namespace ClaudeCodeVS
                     }
                     attached = true;
 
+                    // A child of the agent may have left the console on a different code
+                    // page; while we are attached, put it back. See ReassertConsoleCodePage.
+                    ReassertConsoleCodePage();
+
                     handle = CreateFile("CONIN$",
                         GENERIC_READ_CONSOLE | GENERIC_WRITE_CONSOLE,
                         FILE_SHARE_READ_CONSOLE | FILE_SHARE_WRITE_CONSOLE,
@@ -1165,6 +1209,10 @@ namespace ClaudeCodeVS
                         return 0;
                     }
                     attached = true;
+
+                    // A child of the agent may have left the console on a different code
+                    // page; while we are attached, put it back. See ReassertConsoleCodePage.
+                    ReassertConsoleCodePage();
 
                     // Font APIs operate on the active screen buffer (CONOUT$).
                     handle = CreateFile("CONOUT$",

--- a/Controls/ClaudeCodeControl.AgentCompletion.cs
+++ b/Controls/ClaudeCodeControl.AgentCompletion.cs
@@ -943,6 +943,8 @@ namespace ClaudeCodeVS
         /// </summary>
         private void ReassertConsoleCodePage()
         {
+            if (_settings?.KeepTerminalCodePage == false) return;
+
             try
             {
                 uint current = GetConsoleOutputCP();

--- a/Controls/ClaudeCodeControl.Interop.cs
+++ b/Controls/ClaudeCodeControl.Interop.cs
@@ -461,6 +461,19 @@ namespace ClaudeCodeVS
         private static extern bool FreeConsole();
 
         /// <summary>
+        /// Reads the code page the attached console uses for output.
+        /// </summary>
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern uint GetConsoleOutputCP();
+
+        /// <summary>
+        /// Sets the code page the attached console uses for output.
+        /// </summary>
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool SetConsoleOutputCP(uint wCodePageID);
+
+
+        /// <summary>
         /// Returns the window handle of the console attached to the calling process, or IntPtr.Zero when none
         /// </summary>
         [DllImport("kernel32.dll")]

--- a/Controls/ClaudeCodeControl.SettingsDialog.cs
+++ b/Controls/ClaudeCodeControl.SettingsDialog.cs
@@ -704,6 +704,18 @@ namespace ClaudeCodeVS
             }
             terminalStack.Children.Add(consoleFontSizeCombo);
 
+            terminalStack.Children.Add(MakeSectionHeader("Encoding", themeFg));
+
+            var keepCodePageCheck = MakeCheckBox(
+                "Keep the terminal on its launch code page (UTF-8)",
+                "The console's code page is shared with every process the agent starts. A command that changes it - " +
+                "PowerShell's [Console]::OutputEncoding, a chcp inside a shell command, some .NET CLI tools - leaves it " +
+                "changed after it exits, and from then on the terminal renders mojibake until it is restarted.\n\n" +
+                "While this is on, the code page is put back as soon as the drift is noticed. Turn it off if an agent " +
+                "workflow deliberately switches the console to a different code page and needs it to stay there.",
+                _settings.KeepTerminalCodePage, themeFg);
+            terminalStack.Children.Add(keepCodePageCheck);
+
             // "Disable clipboard" relies on simulated keystrokes that only conhost (Command Prompt)
             // accepts, so the toggle is enabled only while Command Prompt is selected. Keep it in sync
             // with the terminal-type radios live, and uncheck it when switching to Windows Terminal so
@@ -1028,6 +1040,7 @@ namespace ClaudeCodeVS
                 : LayoutOrientation.Horizontal;
             bool newHidePromptPanel = hidePromptPanelCheck.IsChecked == true;
             bool newUseNativeMode = nativeModeCheck.IsChecked == true;
+            bool newKeepTerminalCodePage = keepCodePageCheck.IsChecked == true;
             // Native mode launches no console at all, so the terminal type is pinned rather than left
             // pointing at a Windows Terminal that would never be started (and never be validated).
             TerminalType newTerminalType = !newUseNativeMode && wtRadio.IsChecked == true
@@ -1110,6 +1123,7 @@ namespace ClaudeCodeVS
             _settings.UseNativeMode           = newUseNativeMode;
             _settings.ConsoleFontFaceName     = newConsoleFont;
             _settings.ConsoleFontSizePt       = newConsoleFontSize;
+            _settings.KeepTerminalCodePage    = newKeepTerminalCodePage;
             _settings.NativeChatFontFaceName  = newChatFont;
             _settings.NativeChatFontSizePt    = newChatFontSize;
 

--- a/Models/ClaudeCodeModels.cs
+++ b/Models/ClaudeCodeModels.cs
@@ -665,6 +665,17 @@ namespace ClaudeCodeVS
         public int ConsoleFontSizePt { get; set; } = 0;
 
         /// <summary>
+        /// Whether the embedded terminal is kept on the code page it was launched with (UTF-8 / 65001).
+        /// The code page belongs to the console and is shared with everything the agent spawns, so a child
+        /// process that changes it - PowerShell's [Console]::OutputEncoding, a chcp inside a shell command,
+        /// some .NET CLI tools - leaves the terminal decoding every later byte with the wrong one until it
+        /// is restarted. While enabled, the completion watcher puts the launch code page back as soon as it
+        /// notices the drift. Turn this off if an agent workflow deliberately switches the console to a
+        /// different code page and needs it to stay there.
+        /// </summary>
+        public bool KeepTerminalCodePage { get; set; } = true;
+
+        /// <summary>
         /// Whether the terminal is currently detached into a separate tool window tab
         /// </summary>
         public bool IsTerminalDetached { get; set; } = false;

--- a/Tests/SettingsPersistenceTests.cs
+++ b/Tests/SettingsPersistenceTests.cs
@@ -132,5 +132,22 @@ namespace ClaudeCodeExtension.Tests
             Assert.AreEqual((int)AiProvider.Reasonix, (int)toSave["SelectedProvider"]);
             Assert.AreEqual(1, (int)toSave["SelectedEffortLevel"]);
         }
+
+        /// <summary>
+        /// The terminal is launched as UTF-8, so keeping it there is the default; a user who has an
+        /// agent workflow that deliberately switches the console code page can turn it off, and that
+        /// choice has to survive a save/load round trip.
+        /// </summary>
+        [TestMethod]
+        public void KeepTerminalCodePage_DefaultsToOnAndRoundTrips()
+        {
+            Assert.IsTrue(new ClaudeCodeSettings().KeepTerminalCodePage);
+
+            var settings = new ClaudeCodeSettings { KeepTerminalCodePage = false };
+
+            string json = ClaudeCodeControl.SerializeJsonIndented(settings);
+
+            Assert.IsFalse((bool)JObject.Parse(json)["KeepTerminalCodePage"]);
+        }
     }
 }


### PR DESCRIPTION
Closes #145.

## What this changes

`ReassertConsoleCodePage()` in `ClaudeCodeControl.AgentCompletion.cs` puts the console's output code page back to 65001 — the one the launch script starts it with — whenever it has drifted. It is called from all three places that already `AttachConsole` to the agent's console: `TryCaptureConsoleText`, `IsTerminalInMouseInputMode` and `TryAdjustConhostFontSize`. Two P/Invokes (`GetConsoleOutputCP`, `SetConsoleOutputCP`) sit next to the existing console declarations in `ClaudeCodeControl.Interop.cs`.

The behaviour is behind a setting, `KeepTerminalCodePage`, **on by default** and exposed in the settings dialog under **Terminal → Encoding** as *"Keep the terminal on its launch code page (UTF-8)"*. Turning it off restores today's behaviour exactly.

## Why

The code page belongs to the console, not to the process that changes it, and that console is shared with everything the agent spawns. A child that calls `SetConsoleOutputCP` leaves it changed after it exits — in the session that prompted this, a PowerShell command set `[Console]::OutputEncoding` to CP1252 so it could decode `TF.exe` output, and everything the agent wrote from the next line on was mojibake. Later in the same session another command set it back to UTF-8 and the display recovered just as abruptly, which is what pins the cause to the live code page rather than to anything in the launch path.

The panel suffers more than a standalone console would: the agent owns the input line, so there is no comfortable way to type `chcp 65001`, and with `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` the broken frames stay in the scrollback. Since the completion watcher is attached about once a second, the correction lands almost immediately instead of costing the user the session.

## Notes for review

- **The setting exists because this overrules a child that changed the code page deliberately.** Default on, since a terminal the extension launched as UTF-8 should stay UTF-8; off is a clean escape hatch for a workflow that needs otherwise.
- **Only output written after the correction benefits.** Text already in the scroll buffer was damaged when it was written and cannot be recovered.
- `current == 0` (the call failing) is treated as "leave it alone".
- Every drift is written to `terminal-launch.log`, so "the terminal suddenly went to garbage" becomes a diagnosable event rather than a mystery.

## Verification

- `MSBuild ClaudeCodeExtension.sln -p:Configuration=Release` — 0 errors, no new warnings, VSIX produced.
- Unit tests: **240 passed, 0 failed** — including a new one covering the setting's default and its JSON round trip.
- Not coverable by an automated test: the drift itself needs a running VS with an embedded terminal. I verified the mechanism outside the extension instead — a PowerShell child sharing the console reports `chcp` = 65001, and setting `[Console]::OutputEncoding` there changes it for the parent too, which is exactly the failure this guards against.
