### PR TITLE
Stop adopting a leftover empty conhost subkey as user state

### DIFF
--- a/Controls/ClaudeCodeControl.Cleanup.cs
+++ b/Controls/ClaudeCodeControl.Cleanup.cs
@@ -136,6 +136,14 @@ namespace ClaudeCodeVS
                 // fields (provider, model, effort) are written to disk.
                 _isShuttingDown = true;
 
+                // Last chance to undo the console registry changes if a launch left them set.
+                // Idempotent; see RestoreConsoleRegistryOnAllExitPaths in the Terminal partial.
+                if (RestoreConsoleRegistryOnAllExitPaths)
+                {
+                    RestoreConsoleFontRegistry();
+                    RestoreConsoleColorsRegistry();
+                }
+
                 // Persist the latest UI state before tearing down the control.
                 SaveSettings();
 

--- a/Controls/ClaudeCodeControl.Terminal.cs
+++ b/Controls/ClaudeCodeControl.Terminal.cs
@@ -1794,6 +1794,14 @@ namespace ClaudeCodeVS
                 {
                     _terminalLifecycleSemaphore.Release();
                 }
+
+                // Catches the paths the normal restore above never reaches - an exception thrown
+                // inside the embed block, or the method left early. Idempotent; see the flag.
+                if (RestoreConsoleRegistryOnAllExitPaths)
+                {
+                    RestoreConsoleFontRegistry();
+                    RestoreConsoleColorsRegistry();
+                }
             }
         }
 
@@ -1992,6 +2000,20 @@ namespace ClaudeCodeVS
         /// Stored in the conhost.exe-specific subkey (HKCU\Console\%SystemRoot%_System32_conhost.exe),
         /// because the parent HKCU\Console CodePage value is ignored in practice.
         /// </summary>
+        /// <summary>
+        /// Opt-in for restoring the console registry on paths other than the normal end of a
+        /// launch: the launch method's finally block and control teardown.
+        ///
+        /// Off by default because it changes when the restore runs, and the failure it guards
+        /// against (VS crashing or being killed between save and restore) cannot be covered by
+        /// the unit tests. The restore itself is idempotent - it returns immediately unless
+        /// _consoleFontSaved is set - so switching this on only adds attempts, never double
+        /// restores. Flip to true to enable.
+        /// </summary>
+        /// Declared static readonly rather than const so the guarded blocks still compile
+        /// and are checked by the compiler - a const false would make them unreachable code.
+        private static readonly bool RestoreConsoleRegistryOnAllExitPaths = false;
+
         private object _savedConsoleCodePage;
 
         /// <summary>
@@ -2083,7 +2105,11 @@ namespace ClaudeCodeVS
                 // CodePage lives in the per-executable conhost.exe subkey; the parent Console\CodePage is ignored by conhost.exe.
                 using (var existing = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(ConsoleConhostSubkeyPath, writable: false))
                 {
-                    _cmdConhostSubkeyExisted = existing != null;
+                    // A key with no values under it is one of our own leftovers: DeleteSubKey lost
+                    // a race against a conhost that still had the key open, so only the values went
+                    // away. Treating it as pre-existing user state would latch this to true forever
+                    // and the restore would never delete the key again.
+                    _cmdConhostSubkeyExisted = existing != null && existing.GetValueNames().Length > 0;
                     _savedConsoleCodePage = existing?.GetValue("CodePage");
                 }
 
@@ -2151,7 +2177,18 @@ namespace ClaudeCodeVS
                 else
                 {
                     // We created the subkey; remove it entirely to leave the registry as we found it.
-                    Microsoft.Win32.Registry.CurrentUser.DeleteSubKey(ConsoleConhostSubkeyPath, throwOnMissingSubKey: false);
+                    try
+                    {
+                        Microsoft.Win32.Registry.CurrentUser.DeleteSubKey(ConsoleConhostSubkeyPath, throwOnMissingSubKey: false);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Expected when the conhost we created it for still holds a handle: the
+                        // values are gone but the key survives until that handle closes. Harmless
+                        // in itself - the value-count guard above keeps the next launch from
+                        // adopting the empty key as user state.
+                        LogTerminalLaunch($"DeleteSubKey({ConsoleConhostSubkeyPath}) failed: {ex.Message}");
+                    }
                 }
 
                 _consoleFontSaved = false;

--- a/Controls/ClaudeCodeControl.Terminal.cs
+++ b/Controls/ClaudeCodeControl.Terminal.cs
@@ -2001,17 +2001,23 @@ namespace ClaudeCodeVS
         /// because the parent HKCU\Console CodePage value is ignored in practice.
         /// </summary>
         /// <summary>
-        /// Opt-in for restoring the console registry on paths other than the normal end of a
-        /// launch: the launch method's finally block and control teardown.
+        /// Maintainer toggle, in the spirit of EnablePasteFromClipboardMenu: restore the console
+        /// registry on the paths the normal restore never reaches - the launch method's finally
+        /// block and control teardown. Flip this to true to enable it.
         ///
-        /// Off by default because it changes when the restore runs, and the failure it guards
-        /// against (VS crashing or being killed between save and restore) cannot be covered by
-        /// the unit tests. The restore itself is idempotent - it returns immediately unless
-        /// _consoleFontSaved is set - so switching this on only adds attempts, never double
-        /// restores. Flip to true to enable.
+        /// Deliberately not a user setting. There is no sensible reason a user would want their
+        /// console registry left dirty after a crash, so there is nothing here for them to decide;
+        /// what is open is whether the timing change is worth taking, which is your call.
+        ///
+        /// Off by default because it moves when the restore runs, and the failure it guards against
+        /// - VS crashing or being killed between save and restore - cannot be reproduced in the unit
+        /// tests. The restore itself is idempotent: it returns immediately unless _consoleFontSaved
+        /// is set, so enabling this only adds attempts, never double restores.
+        ///
+        /// static readonly rather than const because the guarded blocks are plain if statements:
+        /// a const false would turn them into unreachable code (CS0162). EnablePasteFromClipboardMenu
+        /// can stay const because it is used in a compound condition.
         /// </summary>
-        /// Declared static readonly rather than const so the guarded blocks still compile
-        /// and are checked by the compiler - a const false would make them unreachable code.
         private static readonly bool RestoreConsoleRegistryOnAllExitPaths = false;
 
         private object _savedConsoleCodePage;


### PR DESCRIPTION
Closes #146.

## What this changes

**Active — the actual fix (2 hunks in `ClaudeCodeControl.Terminal.cs`):**

1. `SaveAndSetConsoleFontRegistry()` no longer treats a value-less conhost subkey as pre-existing user state:
   ```csharp
   _cmdConhostSubkeyExisted = existing != null && existing.GetValueNames().Length > 0;
   ```
2. The `DeleteSubKey` in `RestoreConsoleFontRegistry()` gets its own `try/catch` with a log line, instead of falling into the method's outer catch where it disappears.

**Included but switched off (`RestoreConsoleRegistryOnAllExitPaths = false`):** restoring the registry from the launch method's `finally` and from `CleanupResources()`. That covers the paths the normal restore never reaches — an exception thrown inside the embed block, VS closing mid-launch.

## Why

Deleting the subkey right after the embed usually cannot remove it, because the conhost it was created for still holds a handle. Windows drops the values and keeps the key until that handle closes. I measured this: after removing the key by hand and letting the extension launch a terminal, the key is back and empty on every launch.

The empty key is harmless on its own. The damage is at the next launch, where `existing != null` reads as "the user owns this", the restore switches to the wrong branch, and the key is never cleaned up again.

The font values are a second, independent way to leak state — and those sit at the machine-wide `HKCU\Console` level, so they apply to every console window without a profile of its own. On my machine `FaceName = Cascadia Mono` and `FontFamily = 54` had been left behind, which is what started this.

## Notes for review

- **The disabled part is the judgement call.** It is off because it changes *when* the restore runs and the crash paths it guards cannot be covered by the test suite — I did not want to slip a timing change past you in a bug-fix PR. Both restores are idempotent (they return immediately unless `_consoleFontSaved` is set), so enabling it only adds attempts, never double restores. Flip the flag if you want it.
- **It is a maintainer toggle, not a user setting**, modelled on `EnablePasteFromClipboardMenu`. I considered exposing it in the settings dialog and decided against it: there is no sensible reason a user would want their console registry left dirty after a crash, so there is nothing there for them to decide. What is open is whether the timing change is worth taking — your call, not theirs.
- It is declared `static readonly` rather than `const`, unlike `EnablePasteFromClipboardMenu`: the guarded blocks here are plain `if` statements, so a `const false` turns them into unreachable code (CS0162). The existing flag is used in a compound condition, which is why it can stay `const`.
- **Neither part repairs a machine already in this state** — that needs the marker-value idea from the issue, which I left out as too speculative for this PR.

## Verification

- `MSBuild ClaudeCodeExtension.sln -p:Configuration=Release` — 0 errors, VSIX produced, and **no new warnings** (checked specifically for CS0162 after the const/readonly change).
- Unit tests: **239 passed, 0 failed**.
- Manually: with the fix built, the launch/restore cycle no longer leaves the key adopted; the empty-key case is now recognised as ours.
